### PR TITLE
Fix crash on empty directory node and large MSAT

### DIFF
--- a/lib/ole-doc.js
+++ b/lib/ole-doc.js
@@ -352,6 +352,8 @@ OleCompoundDoc.prototype._readMSAT = function(callback) {
                   break;
                else
                   self._MSAT[currMSATIndex] = sectorBuffer.readInt32LE( s );
+
+               currMSATIndex++;
             }
 
             secId = sectorBuffer.readInt32LE( header.secSize - 4 );

--- a/lib/ole-doc.js
+++ b/lib/ole-doc.js
@@ -161,9 +161,11 @@ DirectoryTree.prototype._getChildIds = function( storageEntry ) {
       }
    };
 
-   childIds.push( storageEntry.storageDirId );
-   var rootChildEntry = self._entries[storageEntry.storageDirId];
-   visit( rootChildEntry );
+   if ( storageEntry.storageDirId > -1 ) {
+      childIds.push( storageEntry.storageDirId );
+      var rootChildEntry = self._entries[storageEntry.storageDirId];
+      visit( rootChildEntry );
+   }
 
    return childIds;
 };


### PR DESCRIPTION
When there's a directory entry that doesn't contain any children, the lib crashes:

```
node_modules\ole-doc\lib\ole-doc.js:161
      if ( visitEntry.left !== DirectoryTree.Leaf ) {
                     ^
TypeError: Cannot read property 'left' of undefined
    at visit (node_modules\ole-doc\lib\ole-doc.js:161:22)
    at DirectoryTree._getChildIds (node_modules\ole-doc\lib\ole-doc.js:174:4)
    at DirectoryTree._buildHierarchy (node_modules\ole-doc\lib\ole-doc.js:135:24)
    at DirectoryTree._buildHierarchy (node_modules\ole-doc\lib\ole-doc.js:152:12)
    at Function._.each._.forEach (node_modules\ole-doc\node_modules\underscore\underscore.js:86:24)
    at DirectoryTree._buildHierarchy (node_modules\ole-doc\lib\ole-doc.js:151:6)
    at DirectoryTree.load (node_modules\ole-doc\lib\ole-doc.js:127:12)
    at OleCompoundDoc._readSectors (node_modules\ole-doc\lib\ole-doc.js:410:10)
    at Object.async.whilst (node_modules\ole-doc\node_modules\async\lib\async.js:562:13)
    at async.whilst (node_modules\ole-doc\node_modules\async\lib\async.js:558:23)
```

Below there's a fix attached.
